### PR TITLE
Sort versions numerically in 'listall'

### DIFF
--- a/scripts/listall
+++ b/scripts/listall
@@ -140,7 +140,7 @@ list_all() {
         else
             printf "%s\n" "${_version/ }"
         fi
-    done
+    done | sort -t. -k 1,1n -k 2,2n -k 3,3n
     unset _version
 
     if [[ "${opt_porcelain}" == false ]]


### PR DESCRIPTION
With the release of Go 1.10, make sure releases are sorted numerically instead of just lexically:

    ...
    go1.8.5
    go1.8.5rc4
    go1.8.5rc5
    go1.8.6
    go1.8.7
    go1.9
    go1.9.1
    go1.9.2
    go1.9.3
    go1.9.4
    go1.9.5
    go1.10
    go1.10.1

The naïve sorting applied currently sorts version like this:

    go1.10
    go1.10.1
    go1.4
    go1.4.1
    go1.4.2
    go1.4.3
    go1.7.1
    ...